### PR TITLE
Now handling exceptions from getClassifications more gracefully.

### DIFF
--- a/lib/NaturalClassifier.js
+++ b/lib/NaturalClassifier.js
@@ -6,8 +6,17 @@ const TalkifyClassifier = require('talkify-classifier');
 
 function NaturalClassifier(naturalClassifier) {
     this.getClassifications = function GetClassificationsFn(text, callback) {
-        var classifications = naturalClassifier.getClassifications(text);
-        return callback(undefined, classifications);
+        var err = undefined;
+        var classifications = undefined;
+
+        try {
+            classifications = naturalClassifier.getClassifications(text);
+        } catch (e) {
+            classifications = [{label: undefined, value: undefined}];
+            err = e;
+        } finally {
+            callback(err, classifications);
+        }
     };
 
     this.initialize = function InitializeFn(callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talkify-natural-classifier",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Open Source NaturalNode/Natural NLP Classifier for Talkify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Sometimes getClassifications throws errors when it cannot classify
sentence to a certain topic. This is now handled via the try...catch
around the getClassifications method. Any errors are returned as
part of the callback with a undefined topic resolution object in the
classifications array.